### PR TITLE
fix: remove protest message

### DIFF
--- a/asolytics/asolytics.py
+++ b/asolytics/asolytics.py
@@ -504,7 +504,7 @@ def average_install_in_Google_Play(bundleID, gl):
     for stat in statistics:
         if(stat.text.__contains__("Top Countries / Regions")):
             countries = stat.text.replace("Top Countries / Regions\n", "")
-            countries = countries.replace("\n,\n", ", ").replace("Russia", "Russian Terrorist State")
+            countries = countries.replace("\n,\n", ", ")
             break
 
     if(countries == None):


### PR DESCRIPTION
Suggesting removing this protest message. IMHO mixing politics and open source is a bad idea.

The incorporation of political messages in open-source code can have detrimental effects, including a loss of trust among users and contributors.

I support Ukraine and wish for the war to come to an end.